### PR TITLE
Update Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,10 @@
 	```
 	nano ~/.config/lxsession/LXDE-pi/autostart
 	```
+	or
+	```
+	sudo nano /etc/xdg/lxsession/LXDE-pi/autostarts
+	```
 
 	The autostart files needs to look like this:
 	```


### PR DESCRIPTION
```nano ~/.config/lxsession/LXDE-pi/autostart```
This command doesn't work for me. I found in this [link](https://raspberrypi.stackexchange.com/questions/27572/how-to-auto-start-chromium-after-boot-on-the-raspberry-2-2015-01-31-debian-whee) a command that worked.